### PR TITLE
Fix SVG path

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -154,10 +154,6 @@ table.attribute-container {
     user-select: none;
 }
 
-.sprite {
-    -webkit-mask-image: url("../images/largeIcons.svg");
-}
-
 .button-glyph {
     width: 24px;
     height: 24px;
@@ -321,7 +317,6 @@ table.attribute-container {
 #detail-view-placeholder {
     width: 100%;
     height: 100%;
-    text-align-all: center;
 }
 
 #detail-view-placeholder td {

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -19,6 +19,18 @@ class ToolbarHandler {
 
     document.body.appendChild(this.downloadLink);
     this.downloadLink.style = "display: none";
+
+    this.createSpriteBackgroundUrl();
+  }
+
+  createSpriteBackgroundUrl() {
+    var style = document.createElement('style');
+    document.head.appendChild(style);
+    const url = chrome.runtime.getURL('images/largeIcons.svg');
+    style.sheet.insertRule(`.sprite {
+      -webkit-mask-image: url(${url});
+      mask-image: url(${url});
+    }`, 0)
   }
 
   shouldPreserveLog() {


### PR DESCRIPTION
When installing the extension from the web store, the images were not visible

![image](https://user-images.githubusercontent.com/29116195/226302996-c1d5e56b-b154-40b2-9930-22302c318fd6.png)

Somehow the relative URL in the css file did not work when installed from the web store. It seems we need to use `chrome.runtime.getURL` to fix this issue.